### PR TITLE
JWT 만료 날짜 오류 버그 조치

### DIFF
--- a/cookie-Trip/src/main/java/com/cookietrip/domain/auth/token/AuthTokenProvider.java
+++ b/cookie-Trip/src/main/java/com/cookietrip/domain/auth/token/AuthTokenProvider.java
@@ -11,9 +11,9 @@ import java.util.Date;
 public class AuthTokenProvider {
 
     private final Key accessTokenSecretKey;
-    private final Date accessTokenExpiry;
+    private final long accessTokenExpiry;
     private final Key refreshTokenSecretKey;
-    private final Date refreshTokenExpiry;
+    private final long refreshTokenExpiry;
 
     public AuthTokenProvider(
             String accessTokenSecretKeyString,
@@ -22,9 +22,9 @@ public class AuthTokenProvider {
             long refreshTokenExpiry
     ) {
         this.accessTokenSecretKey = generateTokenKey(accessTokenSecretKeyString);
-        this.accessTokenExpiry = generateTokenExpiry(accessTokenExpiry);
+        this.accessTokenExpiry = accessTokenExpiry;
         this.refreshTokenSecretKey = generateTokenKey(refreshTokenSecretKeyString);
-        this.refreshTokenExpiry = generateTokenExpiry(refreshTokenExpiry);
+        this.refreshTokenExpiry = refreshTokenExpiry;
     }
 
     // token key 문자열을 Key Object 로 변환
@@ -49,7 +49,7 @@ public class AuthTokenProvider {
         return AuthToken.of(
                 memberPersonalId,
                 memberRoles,
-                accessTokenExpiry,
+                generateTokenExpiry(accessTokenExpiry),
                 accessTokenSecretKey
         );
     }
@@ -64,7 +64,7 @@ public class AuthTokenProvider {
         return AuthToken.of(
                 memberPersonalId,
                 memberRoles,
-                refreshTokenExpiry,
+                generateTokenExpiry(refreshTokenExpiry),
                 refreshTokenSecretKey
         );
     }


### PR DESCRIPTION
- 해결한 버그 : 토큰 생성 시 만료일자가 잘못 설정되는 버그
- 원인 : AuthTokenProvider에서 정적 필드가 Date로 설정되어 application실행 시 Date값이 고정되어 계속해서 잘못된 토큰 만료일자가 설정되었다.
- 조치 : 잘못된 코드를 수정해주었다.

This closes #15 